### PR TITLE
Add MongoDB pilot example with NostrMQ

### DIFF
--- a/docs/inmdformat.md
+++ b/docs/inmdformat.md
@@ -1,0 +1,52 @@
+# NostrMQ MongoDB Pilot App Design
+
+This document outlines a simple pilot application using **NostrMQ** for remote MongoDB access. The goal is to allow a client to send encrypted requests over Nostr and receive responses containing data or update results. Each request is validated against a whitelist of allowed sender pubkeys.
+
+## Overview
+
+1. **Local MongoDB** – The server runs a MongoDB instance accessible via `mongodb://localhost:27017`.
+2. **Database Selection** – Each database is associated with an `npub` tag. Clients specify the database by including this npub in the payload.
+3. **Actions** – The payload supports `find`, `update`, and `delete` operations. Documents are selected with a MongoDB query object.
+4. **Whitelisting** – Only messages from pubkeys present in `ALLOWED_SENDERS` are processed.
+5. **Ephemeral Replies** – Clients include an ephemeral `replyPubkey` in the request. The server encrypts the response to this pubkey and sends it via NostrMQ.
+6. **Status Codes** – Responses include a `status` field (`ok` or `error`) and optional result data.
+
+## Payload Format
+
+```json
+{
+  "dbNpub": "<npub identifying the database>",
+  "collection": "users",
+  "action": "find" | "update" | "delete",
+  "query": { "id": 1 },
+  "update": { "$set": { "name": "Bob" } },
+  "replyPubkey": "<ephemeral npub>"
+}
+```
+
+## Request Flow
+
+1. Client generates an ephemeral key pair for the reply channel.
+2. Client sends the payload using `send()` targeting the server pubkey.
+3. Server receives the message with `receive()` and validates:
+   - Sender is whitelisted.
+   - Payload includes `dbNpub`, `collection`, `action`, and `replyPubkey`.
+4. Server performs the MongoDB operation and constructs a response:
+
+```json
+{
+  "status": "ok",
+  "data": [/* documents or update result */]
+}
+```
+
+5. Server sends the response back encrypted to `replyPubkey`.
+6. Client listens with `receive()` using its ephemeral private key and processes the result.
+
+## Implementation Notes
+
+- Environment variables hold the server private key (`NOSTRMQ_PRIVKEY`), relay list (`NOSTRMQ_RELAYS`), and allowed sender pubkeys (`ALLOWED_SENDERS`).
+- The mapping from `dbNpub` to actual MongoDB database names can live in a simple JavaScript object.
+- To keep the example self‑contained, PoW is disabled during testing.
+
+See [examples/mongo-pilot-server.js](../examples/mongo-pilot-server.js) and [examples/mongo-pilot-client.js](../examples/mongo-pilot-client.js) for runnable snippets.

--- a/examples/mongo-pilot-client.js
+++ b/examples/mongo-pilot-client.js
@@ -1,0 +1,60 @@
+/**
+ * MongoDB Pilot Client using NostrMQ
+ *
+ * Demonstrates sending a request to the pilot server and reading the response
+ * using an ephemeral key pair.
+ *
+ * Expected environment variables:
+ *   TARGET_PUBKEY      - server pubkey in hex
+ *   NOSTRMQ_RELAYS     - comma separated relay URLs
+ *
+ * Usage: node examples/mongo-pilot-client.js
+ */
+import { send, receive } from '../dist/index.js';
+import { generatePrivateKey, getPublicKey } from 'nostr-tools';
+
+const TARGET = process.env.TARGET_PUBKEY;
+const RELAYS = process.env.NOSTRMQ_RELAYS?.split(',');
+if (!TARGET || !RELAYS?.length) {
+  console.error('Missing TARGET_PUBKEY or NOSTRMQ_RELAYS');
+  process.exit(1);
+}
+
+// create ephemeral keys for reply
+const replyPriv = generatePrivateKey();
+const replyPub = getPublicKey(replyPriv);
+
+async function run() {
+  // listen for the reply
+  const sub = receive({
+    onMessage: (payload) => {
+      console.log('Response:', payload);
+      sub.close();
+      process.exit(0);
+    },
+    privkey: replyPriv,
+    relays: RELAYS,
+    pow: false,
+  });
+
+  // send request
+  await send({
+    target: TARGET,
+    payload: {
+      dbNpub: 'exampledbnpub',
+      collection: 'users',
+      action: 'find',
+      query: { id: 1 },
+      replyPubkey: replyPub,
+    },
+    relays: RELAYS,
+    pow: false,
+  });
+
+  console.log('Request sent. Waiting for reply...');
+}
+
+run().catch((err) => {
+  console.error('Client error:', err);
+  process.exit(1);
+});

--- a/examples/mongo-pilot-server.js
+++ b/examples/mongo-pilot-server.js
@@ -1,0 +1,85 @@
+/**
+ * MongoDB Pilot Server using NostrMQ
+ *
+ * Run a local MongoDB instance and listen for requests over Nostr.
+ * The server expects environment variables:
+ *   NOSTRMQ_PRIVKEY  - hex private key used to decrypt and send messages
+ *   NOSTRMQ_RELAYS   - comma separated relay URLs
+ *   ALLOWED_SENDERS  - comma separated pubkeys allowed to send requests
+ *
+ * Usage: node examples/mongo-pilot-server.js
+ */
+import { send, receive } from '../dist/index.js';
+import { MongoClient } from 'mongodb';
+
+const PRIVKEY = process.env.NOSTRMQ_PRIVKEY;
+const RELAYS = process.env.NOSTRMQ_RELAYS?.split(',');
+const ALLOWED = process.env.ALLOWED_SENDERS?.split(',') || [];
+
+if (!PRIVKEY || !RELAYS?.length) {
+  console.error('Missing NOSTRMQ_PRIVKEY or NOSTRMQ_RELAYS');
+  process.exit(1);
+}
+
+const DB_MAP = {
+  // map npub hex -> database name
+  // example: 'npub1example...': 'testdb'
+};
+
+async function start() {
+  const mongo = new MongoClient('mongodb://localhost:27017');
+  await mongo.connect();
+  console.log('Connected to MongoDB');
+
+  const subscription = receive({
+    onMessage: async (payload, sender) => {
+      if (!ALLOWED.includes(sender)) {
+        console.log('Ignored message from', sender);
+        return;
+      }
+      const { dbNpub, collection, action, query, update, replyPubkey } = payload;
+      if (!dbNpub || !collection || !action || !replyPubkey) return;
+      const dbName = DB_MAP[dbNpub];
+      if (!dbName) return;
+      const db = mongo.db(dbName).collection(collection);
+      let result;
+      try {
+        if (action === 'find') {
+          result = await db.find(query || {}).toArray();
+        } else if (action === 'update') {
+          result = await db.updateMany(query || {}, update || {});
+        } else if (action === 'delete') {
+          result = await db.deleteMany(query || {});
+        } else {
+          throw new Error('Invalid action');
+        }
+        await send({
+          target: replyPubkey,
+          payload: { status: 'ok', data: result },
+          pow: false,
+        });
+      } catch (err) {
+        await send({
+          target: replyPubkey,
+          payload: { status: 'error', error: err.message },
+          pow: false,
+        });
+      }
+    },
+    relays: RELAYS,
+    privkey: PRIVKEY,
+    pow: false,
+  });
+
+  console.log('Server listening for NostrMQ messages');
+  process.on('SIGINT', async () => {
+    await subscription.close();
+    await mongo.close();
+    process.exit();
+  });
+}
+
+start().catch((err) => {
+  console.error('Startup error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- document a design for a MongoDB pilot app using NostrMQ
- add example server and client scripts

## Testing
- `npm run build`
- `node test-local-package.js`


------
https://chatgpt.com/codex/tasks/task_e_6865da524908832fafc9ce7261e6ef50